### PR TITLE
Check if emote name provided when creating emote

### DIFF
--- a/src/Commands/Guild/addemote.ts
+++ b/src/Commands/Guild/addemote.ts
@@ -205,6 +205,7 @@ export const command: Command = {
  * @return {boolean}      does the emote work as an emote name
  */
 function validEmoteName(emoteName: string): boolean {
+    if (!emoteName) return false;
     if (/^[a-zA-Z0-9_]*$/.test(emoteName)) {
         return true;
     } else {


### PR DESCRIPTION
## Description:
Fixes an error that would happen if a user did not post an emote name with the message